### PR TITLE
Move example-scripts-only dependencies out. Closes #9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,13 +31,17 @@ setuptools.setup(
     include_package_data=True,
     install_requires=[
         'numpy==1.18.3',
-        'pyyaml',
         'opencv-python==3.4.2.16',
         'onvif-zeep',
-        'screeninfo',
-        'imutils',
         'camml',
     ],
+    extra_require={
+        'examples': [
+            'pyyaml',
+            'imutils',
+            'screeninfo',
+        ],
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
These are dependencies of the example scripts, not of the package so we don't want them to be installed when the package is installed from PyPI using pip.